### PR TITLE
Fix TypeError in blockchain.stream and improve error handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "ruamel.yaml",
     "diff_match_patch",
     "asn1crypto",
+    "types-requests>=2.32.0.20250328",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hive-nectar"
-version = "0.0.5"
+version = "0.0.6"
 description = "Unofficial Python library for HIVE"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/nectar/blockchain.py
+++ b/src/nectar/blockchain.py
@@ -633,7 +633,7 @@ class Blockchain(object):
 
                     if not bool(block_batch):
                         raise BatchedCallsNotSupported(
-                            f"{self.rpc.url} Doesn't support batched calls"
+                            f"{self.blockchain.rpc.url} Doesn't support batched calls"
                         )
                     if not isinstance(block_batch, list):
                         block_batch = [block_batch]

--- a/src/nectar/blockchain.py
+++ b/src/nectar/blockchain.py
@@ -40,7 +40,8 @@ if not FUTURES_MODULE:
 # maybe add the task back into the queue, then make your own handler and pass it in
 def default_handler(name, exception, *args, **kwargs):
     log.warn(
-        "%s raised %s with args %s and kwargs %s" % (name, str(exception), repr(args), repr(kwargs))
+        "%s raised %s with args %s and kwargs %s"
+        % (name, str(exception), repr(args), repr(kwargs))
     )
     pass
 
@@ -277,7 +278,9 @@ class Blockchain(object):
             raise OfflineHasNoRPCException("No RPC available in offline mode!")
         self.blockchain.rpc.set_next_node_on_empty_reply(False)
         if self.blockchain.rpc.get_use_appbase():
-            ret = self.blockchain.rpc.get_transaction({"id": transaction_id}, api="account_history")
+            ret = self.blockchain.rpc.get_transaction(
+                {"id": transaction_id}, api="account_history"
+            )
         else:
             ret = self.blockchain.rpc.get_transaction(transaction_id, api="database")
         return ret
@@ -548,7 +551,9 @@ class Blockchain(object):
                             checked_results.append(b)
                             result_block_nums.append(int(b.block_num))
 
-                    missing_block_num = list(set(block_num_list).difference(set(result_block_nums)))
+                    missing_block_num = list(
+                        set(block_num_list).difference(set(result_block_nums))
+                    )
                     while len(missing_block_num) > 0:
                         for blocknum in missing_block_num:
                             try:
@@ -627,7 +632,9 @@ class Blockchain(object):
                                 )
 
                     if not bool(block_batch):
-                        raise BatchedCallsNotSupported()
+                        raise BatchedCallsNotSupported(
+                            f"{self.rpc.url} Doesn't support batched calls"
+                        )
                     if not isinstance(block_batch, list):
                         block_batch = [block_batch]
                     for block in block_batch:

--- a/src/nectar/blockchain.py
+++ b/src/nectar/blockchain.py
@@ -39,9 +39,8 @@ if not FUTURES_MODULE:
 # default exception handler. if you want to take some action on failed tasks
 # maybe add the task back into the queue, then make your own handler and pass it in
 def default_handler(name, exception, *args, **kwargs):
-    log.warn(
-        "%s raised %s with args %s and kwargs %s"
-        % (name, str(exception), repr(args), repr(kwargs))
+    log.warning(
+        f"{name} raised {exception} with args {args!r} and kwargs {kwargs!r}"
     )
     pass
 
@@ -68,7 +67,7 @@ class Worker(Thread):
                 # get a task and raise immediately if none available
                 func, args, kwargs = self.queue.get(False)
                 self.idle.clear()
-            except:
+            except Exception:
                 # no work to do
                 # if not self.idle.is_set():
                 #  print >> stdout, '%s is idle' % self.name
@@ -176,7 +175,7 @@ class Pool:
                 # get a result, raises empty exception immediately if none available
                 results.append(self.resultQueue.get(False))
                 self.resultQueue.task_done()
-        except:
+        except Exception:
             return results
         return results
 

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -485,9 +485,9 @@ class GrapheneRPC(object):
         try:
             if response is None:
                 try:
-                    ret = json.loads(reply, strict=False, encoding="utf-8")
+                    ret = json.loads(reply, strict=False)
                 except ValueError:
-                    log.error(f"Non-JSON response: {reply}")
+                    log.error(f"Non-JSON response: {reply} Node: {self.url}")
                     self._check_for_server_error(reply)
                     raise RPCError("Invalid response format")
             else:
@@ -520,6 +520,7 @@ class GrapheneRPC(object):
             self.nodes.reset_error_cnt_call()
             return ret["result"]
         else:
+            log.error(f"Unexpected response format: {ret} Node: {self.url}")
             raise RPCError(f"Unexpected response format: {ret}")
 
     # End of Deprecated methods

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -502,7 +502,7 @@ class GrapheneRPC(object):
                 error_message = ret["error"].get(
                     "detail", ret["error"].get("message", "Unknown error")
                 )
-            raise RPCError(error_message)
+                raise RPCError(error_message)
         elif isinstance(ret, list):
             ret_list = []
             for r in ret:

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -498,9 +498,12 @@ class GrapheneRPC(object):
         log.debug(f"Reply: {json.dumps(reply)}")
 
         if isinstance(ret, dict) and "error" in ret:
-            error_message = ret["error"].get(
-                "detail", ret["error"].get("message", "Unknown error")
-            )
+            if isinstance(ret, dict):
+                error_message = ret["error"].get(
+                    "detail", ret["error"].get("message", "Unknown error")
+                )
+            else:
+                error_message = str(ret)
             raise RPCError(error_message)
         elif isinstance(ret, list):
             ret_list = []

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -498,12 +498,12 @@ class GrapheneRPC(object):
         log.debug(f"Reply: {json.dumps(reply)}")
 
         if isinstance(ret, dict) and "error" in ret:
-            if isinstance(ret, dict):
+            if isinstance(ret["error"], dict):
                 error_message = ret["error"].get(
                     "detail", ret["error"].get("message", "Unknown error")
                 )
             else:
-                error_message = str(ret)
+                error_message = str(ret["error"])
             raise RPCError(error_message)
         elif isinstance(ret, list):
             ret_list = []

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -46,7 +46,7 @@ log = logging.getLogger(__name__)
 
 
 class SessionInstance(object):
-    """Singelton for the Session Instance"""
+    """Singleton for the Session Instance"""
 
     instance = None
 
@@ -59,7 +59,7 @@ def set_session_instance(instance):
 def shared_session_instance():
     """Get session instance"""
     if REQUEST_MODULE is None:
-        raise Exception()
+        raise Exception("Requests module is not available.")
     if not SessionInstance.instance:
         SessionInstance.instance = requests.Session()
     return SessionInstance.instance
@@ -68,7 +68,7 @@ def shared_session_instance():
 def create_ws_instance(use_ssl=True, enable_multithread=True):
     """Get websocket instance"""
     if WEBSOCKET_MODULE is None:
-        raise Exception()
+        raise Exception("WebSocket module is not available.")
     if use_ssl:
         ssl_defaults = ssl.get_default_verify_paths()
         sslopt_ca_certs = {"ca_certs": ssl_defaults.cafile}
@@ -79,47 +79,24 @@ def create_ws_instance(use_ssl=True, enable_multithread=True):
 
 class GrapheneRPC(object):
     """
-    This class allows to call API methods synchronously, without callbacks.
+    This class allows calling API methods synchronously, without callbacks.
 
     It logs warnings and errors.
 
     :param str urls: Either a single Websocket/Http URL, or a list of URLs
     :param str user: Username for Authentication
     :param str password: Password for Authentication
-    :param int num_retries: Try x times to num_retries to a node on disconnect, -1 for indefinitely (default is 100)
-    :param int num_retries_call: Repeat num_retries_call times a rpc call on node error (default is 5)
-    :param int timeout: Timeout setting for https nodes (default is 60)
-    :param bool autoconnect: When set to false, connection is performed on the first rpc call (default is True)
-    :param bool use_condenser: Use the old condenser_api rpc protocol on nodes with version
-        0.19.4 or higher. The settings has no effect on nodes with version of 0.19.3 or lower.
-    :param bool use_tor: When set to true, 'socks5h://localhost:9050' is set as proxy
-    :param dict custom_chains: custom chain which should be added to the known chains
-
-    Available APIs:
-
-          * database
-          * network_node
-          * network_broadcast
-
-    Usage:
-
-        .. code-block:: python
-
-            from nectarapi.graphenerpc import GrapheneRPC
-            ws = GrapheneRPC("wss://steemd.pevo.science","","")
-            print(ws.get_account_count())
-
-            ws = GrapheneRPC("https://api.steemit.com","","")
-            print(ws.get_account_count())
-
-    .. note:: This class allows to call methods available via
-              websocket. If you want to use the notification
-              subsystem, please use ``GrapheneWebsocket`` instead.
-
+    :param int num_retries: Number of retries for node connection (default is 100)
+    :param int num_retries_call: Number of retries for RPC calls on node error (default is 5)
+    :param int timeout: Timeout setting for HTTP nodes (default is 60)
+    :param bool autoconnect: Automatically connect on initialization (default is True)
+    :param bool use_condenser: Use the old condenser_api RPC protocol
+    :param bool use_tor: Use Tor proxy for connections
+    :param dict custom_chains: Custom chains to add to known chains
     """
 
     def __init__(self, urls, user=None, password=None, **kwargs):
-        """Init."""
+        """Initialize the RPC client."""
         self.rpc_methods = {"offline": -1, "ws": 0, "jsonrpc": 1, "wsappbase": 2, "appbase": 3}
         self.current_rpc = self.rpc_methods["ws"]
         self._request_id = 0
@@ -454,11 +431,12 @@ class GrapheneRPC(object):
         :raises ValueError: if the server does not respond in proper JSON format
         :raises RPCError: if the server returns an error
         """
-        log.debug(json.dumps(payload))
+        log.debug(f"Payload: {json.dumps(payload)}")
         if self.nodes.working_nodes_count == 0:
-            raise WorkingNodeMissing
+            raise WorkingNodeMissing("No working nodes available.")
         if self.url is None:
             raise RPCConnection("RPC is not connected!")
+
         reply = {}
         response = None
         while True:
@@ -488,13 +466,9 @@ class GrapheneRPC(object):
             except KeyboardInterrupt:
                 raise
             except WebSocketConnectionClosedException as e:
-                if self.nodes.num_retries_call_reached:
-                    self.nodes.increase_error_cnt()
-                    self.nodes.sleep_and_check_retries(str(e), sleep=False, call_retry=False)
-                    self.rpcconnect()
-                else:
-                    # self.nodes.sleep_and_check_retries(str(e), sleep=True, call_retry=True)
-                    self.rpcconnect(next_url=False)
+                self.nodes.increase_error_cnt()
+                self.nodes.sleep_and_check_retries(str(e), sleep=False, call_retry=False)
+                self.rpcconnect()
             except ConnectionError as e:
                 self.nodes.increase_error_cnt()
                 self.nodes.sleep_and_check_retries(str(e), sleep=False, call_retry=False)
@@ -508,48 +482,45 @@ class GrapheneRPC(object):
                 self.nodes.sleep_and_check_retries(str(e), sleep=False, call_retry=False)
                 self.rpcconnect()
 
-        ret = {}
         try:
             if response is None:
-                ret = json.loads(reply, strict=False, encoding="utf-8")
+                try:
+                    ret = json.loads(reply, strict=False, encoding="utf-8")
+                except ValueError:
+                    log.error(f"Non-JSON response: {reply}")
+                    self._check_for_server_error(reply)
+                    raise RPCError("Invalid response format")
             else:
                 ret = response.json()
         except ValueError:
             self._check_for_server_error(reply)
 
-        log.debug(json.dumps(reply))
+        log.debug(f"Reply: {json.dumps(reply)}")
 
         if isinstance(ret, dict) and "error" in ret:
-            if "detail" in ret["error"]:
-                raise RPCError(ret["error"]["detail"])
-            else:
-                raise RPCError(ret["error"]["message"])
+            error_message = ret["error"].get(
+                "detail", ret["error"].get("message", "Unknown error")
+            )
+            raise RPCError(error_message)
+        elif isinstance(ret, list):
+            ret_list = []
+            for r in ret:
+                if isinstance(r, dict) and "error" in r:
+                    error_message = r["error"].get(
+                        "detail", r["error"].get("message", "Unknown error")
+                    )
+                    raise RPCError(error_message)
+                elif isinstance(r, dict) and "result" in r:
+                    ret_list.append(r["result"])
+                else:
+                    ret_list.append(r)
+            self.nodes.reset_error_cnt_call()
+            return ret_list
+        elif isinstance(ret, dict) and "result" in ret:
+            self.nodes.reset_error_cnt_call()
+            return ret["result"]
         else:
-            if isinstance(ret, list):
-                ret_list = []
-                for r in ret:
-                    if isinstance(r, dict) and "error" in r:
-                        if "detail" in r["error"]:
-                            raise RPCError(r["error"]["detail"])
-                        else:
-                            raise RPCError(r["error"]["message"])
-                    elif isinstance(r, dict) and "result" in r:
-                        ret_list.append(r["result"])
-                    else:
-                        ret_list.append(r)
-                self.nodes.reset_error_cnt_call()
-                return ret_list
-            elif isinstance(ret, dict) and "result" in ret:
-                self.nodes.reset_error_cnt_call()
-                return ret["result"]
-            elif isinstance(ret, int):
-                raise RPCError(
-                    "Client returned invalid format. Expected JSON! Output: %s" % (str(ret))
-                )
-            else:
-                self.nodes.reset_error_cnt_call()
-                return ret
-        return ret
+            raise RPCError(f"Unexpected response format: {ret}")
 
     # End of Deprecated methods
     ####################################################################

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -502,8 +502,6 @@ class GrapheneRPC(object):
                 error_message = ret["error"].get(
                     "detail", ret["error"].get("message", "Unknown error")
                 )
-            else:
-                error_message = str(ret["error"])
             raise RPCError(error_message)
         elif isinstance(ret, list):
             ret_list = []

--- a/uv.lock
+++ b/uv.lock
@@ -359,6 +359,7 @@ dependencies = [
     { name = "requests" },
     { name = "ruamel-yaml" },
     { name = "scrypt" },
+    { name = "types-requests" },
     { name = "websocket-client" },
 ]
 
@@ -399,6 +400,7 @@ requires-dist = [
     { name = "requests" },
     { name = "ruamel-yaml" },
     { name = "scrypt" },
+    { name = "types-requests", specifier = ">=2.32.0.20250328" },
     { name = "websocket-client" },
 ]
 
@@ -680,11 +682,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
 ]
 
 [[package]]
@@ -991,27 +993,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.11.5"
+version = "0.11.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/71/5759b2a6b2279bb77fe15b1435b89473631c2cd6374d45ccdb6b785810be/ruff-0.11.5.tar.gz", hash = "sha256:cae2e2439cb88853e421901ec040a758960b576126dab520fa08e9de431d1bef", size = 3976488 }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/11/bcef6784c7e5d200b8a1f5c2ddf53e5da0efec37e6e5a44d163fb97e04ba/ruff-0.11.6.tar.gz", hash = "sha256:bec8bcc3ac228a45ccc811e45f7eb61b950dbf4cf31a67fa89352574b01c7d79", size = 4010053 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/db/6efda6381778eec7f35875b5cbefd194904832a1153d68d36d6b269d81a8/ruff-0.11.5-py3-none-linux_armv6l.whl", hash = "sha256:2561294e108eb648e50f210671cc56aee590fb6167b594144401532138c66c7b", size = 10103150 },
-    { url = "https://files.pythonhosted.org/packages/44/f2/06cd9006077a8db61956768bc200a8e52515bf33a8f9b671ee527bb10d77/ruff-0.11.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac12884b9e005c12d0bd121f56ccf8033e1614f736f766c118ad60780882a077", size = 10898637 },
-    { url = "https://files.pythonhosted.org/packages/18/f5/af390a013c56022fe6f72b95c86eb7b2585c89cc25d63882d3bfe411ecf1/ruff-0.11.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4bfd80a6ec559a5eeb96c33f832418bf0fb96752de0539905cf7b0cc1d31d779", size = 10236012 },
-    { url = "https://files.pythonhosted.org/packages/b8/ca/b9bf954cfed165e1a0c24b86305d5c8ea75def256707f2448439ac5e0d8b/ruff-0.11.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0947c0a1afa75dcb5db4b34b070ec2bccee869d40e6cc8ab25aca11a7d527794", size = 10415338 },
-    { url = "https://files.pythonhosted.org/packages/d9/4d/2522dde4e790f1b59885283f8786ab0046958dfd39959c81acc75d347467/ruff-0.11.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad871ff74b5ec9caa66cb725b85d4ef89b53f8170f47c3406e32ef040400b038", size = 9965277 },
-    { url = "https://files.pythonhosted.org/packages/e5/7a/749f56f150eef71ce2f626a2f6988446c620af2f9ba2a7804295ca450397/ruff-0.11.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6cf918390cfe46d240732d4d72fa6e18e528ca1f60e318a10835cf2fa3dc19f", size = 11541614 },
-    { url = "https://files.pythonhosted.org/packages/89/b2/7d9b8435222485b6aac627d9c29793ba89be40b5de11584ca604b829e960/ruff-0.11.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56145ee1478582f61c08f21076dc59153310d606ad663acc00ea3ab5b2125f82", size = 12198873 },
-    { url = "https://files.pythonhosted.org/packages/00/e0/a1a69ef5ffb5c5f9c31554b27e030a9c468fc6f57055886d27d316dfbabd/ruff-0.11.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5f66f8f1e8c9fc594cbd66fbc5f246a8d91f916cb9667e80208663ec3728304", size = 11670190 },
-    { url = "https://files.pythonhosted.org/packages/05/61/c1c16df6e92975072c07f8b20dad35cd858e8462b8865bc856fe5d6ccb63/ruff-0.11.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80b4df4d335a80315ab9afc81ed1cff62be112bd165e162b5eed8ac55bfc8470", size = 13902301 },
-    { url = "https://files.pythonhosted.org/packages/79/89/0af10c8af4363304fd8cb833bd407a2850c760b71edf742c18d5a87bb3ad/ruff-0.11.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3068befab73620b8a0cc2431bd46b3cd619bc17d6f7695a3e1bb166b652c382a", size = 11350132 },
-    { url = "https://files.pythonhosted.org/packages/b9/e1/ecb4c687cbf15164dd00e38cf62cbab238cad05dd8b6b0fc68b0c2785e15/ruff-0.11.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5da2e710a9641828e09aa98b92c9ebbc60518fdf3921241326ca3e8f8e55b8b", size = 10312937 },
-    { url = "https://files.pythonhosted.org/packages/cf/4f/0e53fe5e500b65934500949361e3cd290c5ba60f0324ed59d15f46479c06/ruff-0.11.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ef39f19cb8ec98cbc762344921e216f3857a06c47412030374fffd413fb8fd3a", size = 9936683 },
-    { url = "https://files.pythonhosted.org/packages/04/a8/8183c4da6d35794ae7f76f96261ef5960853cd3f899c2671961f97a27d8e/ruff-0.11.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b2a7cedf47244f431fd11aa5a7e2806dda2e0c365873bda7834e8f7d785ae159", size = 10950217 },
-    { url = "https://files.pythonhosted.org/packages/26/88/9b85a5a8af21e46a0639b107fcf9bfc31da4f1d263f2fc7fbe7199b47f0a/ruff-0.11.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:81be52e7519f3d1a0beadcf8e974715b2dfc808ae8ec729ecfc79bddf8dbb783", size = 11404521 },
-    { url = "https://files.pythonhosted.org/packages/fc/52/047f35d3b20fd1ae9ccfe28791ef0f3ca0ef0b3e6c1a58badd97d450131b/ruff-0.11.5-py3-none-win32.whl", hash = "sha256:e268da7b40f56e3eca571508a7e567e794f9bfcc0f412c4b607931d3af9c4afe", size = 10320697 },
-    { url = "https://files.pythonhosted.org/packages/b9/fe/00c78010e3332a6e92762424cf4c1919065707e962232797d0b57fd8267e/ruff-0.11.5-py3-none-win_amd64.whl", hash = "sha256:6c6dc38af3cfe2863213ea25b6dc616d679205732dc0fb673356c2d69608f800", size = 11378665 },
-    { url = "https://files.pythonhosted.org/packages/43/7c/c83fe5cbb70ff017612ff36654edfebec4b1ef79b558b8e5fd933bab836b/ruff-0.11.5-py3-none-win_arm64.whl", hash = "sha256:67e241b4314f4eacf14a601d586026a962f4002a475aa702c69980a38087aa4e", size = 10460287 },
+    { url = "https://files.pythonhosted.org/packages/6e/1f/8848b625100ebcc8740c8bac5b5dd8ba97dd4ee210970e98832092c1635b/ruff-0.11.6-py3-none-linux_armv6l.whl", hash = "sha256:d84dcbe74cf9356d1bdb4a78cf74fd47c740bf7bdeb7529068f69b08272239a1", size = 10248105 },
+    { url = "https://files.pythonhosted.org/packages/e0/47/c44036e70c6cc11e6ee24399c2a1e1f1e99be5152bd7dff0190e4b325b76/ruff-0.11.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9bc583628e1096148011a5d51ff3c836f51899e61112e03e5f2b1573a9b726de", size = 11001494 },
+    { url = "https://files.pythonhosted.org/packages/ed/5b/170444061650202d84d316e8f112de02d092bff71fafe060d3542f5bc5df/ruff-0.11.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f2959049faeb5ba5e3b378709e9d1bf0cab06528b306b9dd6ebd2a312127964a", size = 10352151 },
+    { url = "https://files.pythonhosted.org/packages/ff/91/f02839fb3787c678e112c8865f2c3e87cfe1744dcc96ff9fc56cfb97dda2/ruff-0.11.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63c5d4e30d9d0de7fedbfb3e9e20d134b73a30c1e74b596f40f0629d5c28a193", size = 10541951 },
+    { url = "https://files.pythonhosted.org/packages/9e/f3/c09933306096ff7a08abede3cc2534d6fcf5529ccd26504c16bf363989b5/ruff-0.11.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26a4b9a4e1439f7d0a091c6763a100cef8fbdc10d68593df6f3cfa5abdd9246e", size = 10079195 },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/a87f8933fccbc0d8c653cfbf44bedda69c9582ba09210a309c066794e2ee/ruff-0.11.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5edf270223dd622218256569636dc3e708c2cb989242262fe378609eccf1308", size = 11698918 },
+    { url = "https://files.pythonhosted.org/packages/52/7d/8eac0bd083ea8a0b55b7e4628428203441ca68cd55e0b67c135a4bc6e309/ruff-0.11.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f55844e818206a9dd31ff27f91385afb538067e2dc0beb05f82c293ab84f7d55", size = 12319426 },
+    { url = "https://files.pythonhosted.org/packages/c2/dc/d0c17d875662d0c86fadcf4ca014ab2001f867621b793d5d7eef01b9dcce/ruff-0.11.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d8f782286c5ff562e4e00344f954b9320026d8e3fae2ba9e6948443fafd9ffc", size = 11791012 },
+    { url = "https://files.pythonhosted.org/packages/f9/f3/81a1aea17f1065449a72509fc7ccc3659cf93148b136ff2a8291c4bc3ef1/ruff-0.11.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:01c63ba219514271cee955cd0adc26a4083df1956d57847978383b0e50ffd7d2", size = 13949947 },
+    { url = "https://files.pythonhosted.org/packages/61/9f/a3e34de425a668284e7024ee6fd41f452f6fa9d817f1f3495b46e5e3a407/ruff-0.11.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15adac20ef2ca296dd3d8e2bedc6202ea6de81c091a74661c3666e5c4c223ff6", size = 11471753 },
+    { url = "https://files.pythonhosted.org/packages/df/c5/4a57a86d12542c0f6e2744f262257b2aa5a3783098ec14e40f3e4b3a354a/ruff-0.11.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4dd6b09e98144ad7aec026f5588e493c65057d1b387dd937d7787baa531d9bc2", size = 10417121 },
+    { url = "https://files.pythonhosted.org/packages/58/3f/a3b4346dff07ef5b862e2ba06d98fcbf71f66f04cf01d375e871382b5e4b/ruff-0.11.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:45b2e1d6c0eed89c248d024ea95074d0e09988d8e7b1dad8d3ab9a67017a5b03", size = 10073829 },
+    { url = "https://files.pythonhosted.org/packages/93/cc/7ed02e0b86a649216b845b3ac66ed55d8aa86f5898c5f1691797f408fcb9/ruff-0.11.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:bd40de4115b2ec4850302f1a1d8067f42e70b4990b68838ccb9ccd9f110c5e8b", size = 11076108 },
+    { url = "https://files.pythonhosted.org/packages/39/5e/5b09840fef0eff1a6fa1dea6296c07d09c17cb6fb94ed5593aa591b50460/ruff-0.11.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:77cda2dfbac1ab73aef5e514c4cbfc4ec1fbef4b84a44c736cc26f61b3814cd9", size = 11512366 },
+    { url = "https://files.pythonhosted.org/packages/6f/4c/1cd5a84a412d3626335ae69f5f9de2bb554eea0faf46deb1f0cb48534042/ruff-0.11.6-py3-none-win32.whl", hash = "sha256:5151a871554be3036cd6e51d0ec6eef56334d74dfe1702de717a995ee3d5b287", size = 10485900 },
+    { url = "https://files.pythonhosted.org/packages/42/46/8997872bc44d43df986491c18d4418f1caff03bc47b7f381261d62c23442/ruff-0.11.6-py3-none-win_amd64.whl", hash = "sha256:cce85721d09c51f3b782c331b0abd07e9d7d5f775840379c640606d3159cae0e", size = 11558592 },
+    { url = "https://files.pythonhosted.org/packages/d7/6a/65fecd51a9ca19e1477c3879a7fda24f8904174d1275b419422ac00f6eee/ruff-0.11.6-py3-none-win_arm64.whl", hash = "sha256:3567ba0d07fb170b1b48d944715e3294b77f5b7679e8ba258199a250383ccb79", size = 10682766 },
 ]
 
 [[package]]
@@ -1274,6 +1276,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c8/a2/6df94fc5c8e2170d21d7134a565c3a8fb84f9797c1dd65a5976aaf714418/twine-6.1.0.tar.gz", hash = "sha256:be324f6272eff91d07ee93f251edf232fc647935dd585ac003539b42404a8dbd", size = 168404 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/b6/74e927715a285743351233f33ea3c684528a0d374d2e43ff9ce9585b73fe/twine-6.1.0-py3-none-any.whl", hash = "sha256:a47f973caf122930bf0fbbf17f80b83bc1602c9ce393c7845f289a3001dc5384", size = 40791 },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.0.20250328"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/7d/eb174f74e3f5634eaacb38031bbe467dfe2e545bc255e5c90096ec46bc46/types_requests-2.32.0.20250328.tar.gz", hash = "sha256:c9e67228ea103bd811c96984fac36ed2ae8da87a36a633964a21f199d60baf32", size = 22995 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/15/3700282a9d4ea3b37044264d3e4d1b1f0095a4ebf860a99914fd544e3be3/types_requests-2.32.0.20250328-py3-none-any.whl", hash = "sha256:72ff80f84b15eb3aa7a8e2625fffb6a93f2ad5a0c20215fc1dcfa61117bcb2a2", size = 20663 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "hive-nectar"
-version = "0.0.5"
+version = "0.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
Addressed the TypeError encountered while using `blockchain.stream` by enhancing error handling in the GrapheneRPC class to support non-dict responses and improve logging for JSON response handling. Updated the version to 0.0.6 and added a new dependency for type requests.

Fixes #4