### PR TITLE
fix: Update BEACON_URL to use the faster v4v.app mirror and improve c…

### DIFF
--- a/src/nectar/nodelist.py
+++ b/src/nectar/nodelist.py
@@ -21,7 +21,11 @@ STATIC_NODES = [
     "https://anyx.io",
 ]
 
-BEACON_URL = "https://beacon.peakd.com/api/nodes"
+# PeakD beacon API URL is https://beacon.peakd.com/api/nodes
+# devapi.v4v.app is a faster mirror with much less constrained rate limits
+# maintained by the v4v.app team
+
+BEACON_URL = "https://devapi.v4v.app/v2/beacon/nodes/"
 REQUEST_TIMEOUT = 10  # seconds
 CACHE_DURATION = 300  # 5 minutes cache
 
@@ -201,7 +205,11 @@ class NodeList(list):
         return [node["url"] for node in filtered_nodes]
 
     def get_hive_nodes(
-        self, testnet: bool = False, not_working: bool = False, wss: bool = True, https: bool = True
+        self,
+        testnet: bool = False,
+        not_working: bool = False,
+        wss: bool = True,
+        https: bool = True,
     ) -> List[str]:
         """Return a list of Hive node URLs filtered and ordered by score.
 


### PR DESCRIPTION
…ode readability
This pull request updates the Hive node list functionality by switching to a faster, less rate-limited beacon API endpoint and making minor improvements to code formatting for readability.

API endpoint update:

* Changed the `BEACON_URL` in `src/nectar/nodelist.py` to use `https://devapi.v4v.app/v2/beacon/nodes/`, which is a faster mirror with fewer rate limits compared to the previous PeakD beacon API.

Code readability:

* Reformatted the `get_hive_nodes` method parameters in `src/nectar/nodelist.py` to be listed one per line for improved readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated beacon API endpoint to use a new mirror service for improved node data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->