### PR TITLE
feat: stop repeated log spam when retrying a failed network connection, logs only first and last attempt.

### DIFF
--- a/src/nectarapi/node.py
+++ b/src/nectarapi/node.py
@@ -159,7 +159,22 @@ class Nodes(list[Node]):
         call_retry: bool = False,
         showMsg: bool = True,
     ) -> None:
-        """Sleep and check if num_retries is reached"""
+        """
+        Sleep and check if num_retries is reached. If num_retries is reached, raise NumRetriesReached or CallRetriesReached.
+        Only logs first and last retry messages if showMsg is True.
+
+
+        :param errorMsg: Optional error message to log
+        :param sleep: Whether to sleep before retrying
+        :param call_retry: Whether this is a retry for a call error (as opposed to a connection error)
+        :param showMsg: Whether to show retry messages only on the first and last retry
+
+
+        """
+        first_or_last_retry = (
+            self.error_cnt_call == 1 or self.error_cnt_call == self.num_retries_call
+        )
+
         if errorMsg:
             log.warning("Error: {}".format(errorMsg))
         if call_retry:
@@ -171,7 +186,7 @@ class Nodes(list[Node]):
             if self.num_retries >= 0 and self.error_cnt > self.num_retries:
                 raise NumRetriesReached()
 
-        if showMsg:
+        if showMsg and first_or_last_retry:
             if call_retry:
                 log.warning(
                     "Retry RPC Call on node: %s (%d/%d)" % (self.url, cnt, self.num_retries_call)


### PR DESCRIPTION
This pull request refines the retry logic in the `sleep_and_check_retries` method within `src/nectarapi/node.py`. The main improvements are clearer documentation and more user-friendly logging, ensuring that retry messages are only shown on the first and last attempts.

**Documentation improvements:**

* Expanded the docstring for `sleep_and_check_retries` to clarify its behavior, parameters, and exceptions raised, making the method easier to understand and maintain.

**Logging improvements:**

* Updated the retry message logic so that, when `showMsg` is `True`, retry messages are only logged on the first and last retry attempts, reducing log noise during repeated retries. [[1]](diffhunk://#diff-ed2056c573535267ca330e2beaf3b62fae42d918b4a2ddc1503d8f9502a05736L162-R177) [[2]](diffhunk://#diff-ed2056c573535267ca330e2beaf3b62fae42d918b4a2ddc1503d8f9502a05736L174-R189)…and refined logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized retry logging behavior to reduce console noise by restricting retry status messages to display only on first and final retry attempts instead of every iteration. This produces significantly cleaner logs while maintaining essential visibility into retry operations and improving overall readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->