### PR TITLE
Fix downvote to-zero power calculation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hive-nectar"
-version = "1.0.0"
+version = "1.0.1"
 description = "Hive Blockchain Python Library"
 readme = "README.md"
 keywords = ["api", "hive", "library", "rpc"]

--- a/src/nectar/comment.py
+++ b/src/nectar/comment.py
@@ -364,7 +364,11 @@ class Comment(BlockchainObject):
         effective_vests = float(acct.get_effective_vesting_shares())
         final_vests = effective_vests * 1e6
         get_dvp = getattr(acct, "get_downvoting_power", None)
-        downvote_power_pct = float(get_dvp() if callable(get_dvp) else acct.get_voting_power())
+        get_vp = getattr(acct, "get_voting_power", None)
+        voting_power_pct = float(get_vp()) if callable(get_vp) else 0.0
+        downvote_power_pct = (
+            max(float(get_dvp()), voting_power_pct) if callable(get_dvp) else voting_power_pct
+        )
 
         # Reference 100% downvote value using provided sample formula
         power = (100 * 100 / 10000.0) / 50.0  # (vote_power * vote_weight / 10000) / 50
@@ -380,12 +384,13 @@ class Comment(BlockchainObject):
         ui_pct = -percent_needed_ui * (partial / 100.0)
         # Scale to UI percent
         ui_pct_scaled = ui_pct * 100.0
+        can_zero = ui_pct_scaled >= -100.0
         if ui_pct_scaled < -100.0:
             ui_pct_scaled = -100.0
         if ui_pct_scaled > 0.0:
             ui_pct_scaled = 0.0
 
-        if ui_pct_scaled < 0.0 and not nobroadcast:
+        if can_zero and ui_pct_scaled < 0.0 and not nobroadcast:
             self.downvote(abs(ui_pct_scaled), voter=account)
         return ui_pct_scaled
 

--- a/src/nectar/version.py
+++ b/src/nectar/version.py
@@ -1,3 +1,3 @@
 """THIS FILE IS GENERATED FROM nectar PYPROJECT.TOML."""
 
-version = "1.0.0"
+version = "1.0.1"

--- a/src/nectar/vote.py
+++ b/src/nectar/vote.py
@@ -636,7 +636,11 @@ class ActiveVotes(VotesObject):
         effective_vests = float(account.get_effective_vesting_shares())
         final_vests = effective_vests * 1e6  # micro-vests as in reference
         get_dvp = getattr(account, "get_downvoting_power", None)
-        downvote_power_pct = get_dvp() if callable(get_dvp) else account.get_voting_power()
+        get_vp = getattr(account, "get_voting_power", None)
+        voting_power_pct = float(get_vp()) if callable(get_vp) else 0.0
+        downvote_power_pct = (
+            max(float(get_dvp()), voting_power_pct) if callable(get_dvp) else voting_power_pct
+        )
 
         # Reference power model (vote_power=100, vote_weight=100) with divisor 50
         power = (100 * 100 / 10000) / 50.0  # = 0.0002

--- a/src/nectarapi/version.py
+++ b/src/nectarapi/version.py
@@ -1,3 +1,3 @@
 """THIS FILE IS GENERATED FROM nectar PYPROJECT.TOML."""
 
-version = "1.0.0"
+version = "1.0.1"

--- a/src/nectarbase/version.py
+++ b/src/nectarbase/version.py
@@ -1,3 +1,3 @@
 """THIS FILE IS GENERATED FROM nectar PYPROJECT.TOML."""
 
-version = "1.0.0"
+version = "1.0.1"

--- a/src/nectargraphenebase/version.py
+++ b/src/nectargraphenebase/version.py
@@ -1,3 +1,3 @@
 """THIS FILE IS GENERATED FROM nectar PYPROJECT.TOML."""
 
-version = "1.0.0"
+version = "1.0.1"

--- a/tests/nectar/test_comment.py
+++ b/tests/nectar/test_comment.py
@@ -1,17 +1,89 @@
 import unittest
+from unittest import mock
 
 import pytest
 from parameterized import parameterized
 
 from nectar import Hive, exceptions
+from nectar.amount import Amount
 from nectar.comment import AccountPosts, Comment, RankedPosts, RecentByPath, RecentReplies
 from nectar.utils import resolve_authorperm
 from nectar.vote import Vote
 from nectarapi.exceptions import InvalidParameters
+from nectargraphenebase.chains import known_chains
 
 from .nodes import get_hive_nodes
 
 wif = "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"
+
+
+class _FakePrice:
+    def __mul__(self, other):
+        return Amount(1, "HBD", blockchain_instance=other.blockchain)
+
+
+class _FakeBlockchain:
+    backed_token_symbol = "HBD"
+    token_symbol = "HIVE"
+
+    def get_reward_funds(self):
+        return {"recent_claims": "1000000", "reward_balance": "1000.000 HIVE"}
+
+    def get_median_price(self):
+        return _FakePrice()
+
+    def get_network(self):
+        return known_chains["HIVE"]
+
+
+class _FakeAccount:
+    downvoting_power = 100.0
+    voting_power = 100.0
+
+    def __init__(self, account, blockchain_instance=None):
+        self.account = account
+        self.blockchain = blockchain_instance
+
+    def get_effective_vesting_shares(self):
+        return 1_000_000
+
+    def get_downvoting_power(self):
+        return self.downvoting_power
+
+    def get_voting_power(self):
+        return self.voting_power
+
+
+def test_to_zero_does_not_downvote_when_current_power_cannot_zero():
+    _FakeAccount.downvoting_power = 100.0
+    _FakeAccount.voting_power = 100.0
+    comment = Comment.__new__(Comment)
+    dict.__init__(comment)
+    comment["pending_payout_value"] = "1000.000 HBD"
+    comment.blockchain = _FakeBlockchain()
+    comment.downvote = mock.Mock()
+
+    with mock.patch("nectar.account.Account", _FakeAccount):
+        vote_pct = comment.to_zero("alice")
+
+    assert vote_pct == -100.0
+    comment.downvote.assert_not_called()
+
+
+def test_to_zero_uses_regular_voting_power_after_downvote_pool_is_low():
+    _FakeAccount.downvoting_power = 1.0
+    _FakeAccount.voting_power = 50.0
+    comment = Comment.__new__(Comment)
+    dict.__init__(comment)
+    comment["pending_payout_value"] = "1.000 HBD"
+    comment.blockchain = _FakeBlockchain()
+    comment.downvote = mock.Mock()
+
+    with mock.patch("nectar.account.Account", _FakeAccount):
+        vote_pct = comment.to_zero("alice")
+
+    assert vote_pct == -10.0
+    comment.downvote.assert_called_once_with(10.0, voter="alice")
 
 
 class Testcases(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -507,7 +507,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -525,7 +525,7 @@ wheels = [
 
 [[package]]
 name = "hive-nectar"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },
@@ -633,7 +633,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- account for regular voting power when downvote mana is lower, matching Hive downvote mana behavior
- avoid auto-broadcasting a full downvote when the helper determines the post cannot be zeroed
- add regression coverage for low downvote-pool/high regular-VP behavior

## Testing
- uv run pytest -q tests/nectar/test_comment.py::test_to_zero_does_not_downvote_when_current_power_cannot_zero tests/nectar/test_comment.py::test_to_zero_uses_regular_voting_power_after_downvote_pool_is_low
- uv run ruff check src/nectar/comment.py src/nectar/vote.py tests/nectar/test_comment.py
- git diff --check