### PR TITLE
Fix downvote to-zero power calculation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hive-nectar"
-version = "1.0.5"
+version = "1.0.1"
 description = "Hive Blockchain Python Library"
 readme = "README.md"
 keywords = ["api", "hive", "library", "rpc"]

--- a/src/nectar/blockchain/models/vote.py
+++ b/src/nectar/blockchain/models/vote.py
@@ -640,7 +640,11 @@ class ActiveVotes(VotesObject):
         effective_vests = float(account.get_effective_vesting_shares())
         final_vests = effective_vests * 1e6  # micro-vests as in reference
         get_dvp = getattr(account, "get_downvoting_power", None)
-        downvote_power_pct = get_dvp() if callable(get_dvp) else account.get_voting_power()
+        get_vp = getattr(account, "get_voting_power", None)
+        voting_power_pct = float(get_vp()) if callable(get_vp) else 0.0
+        downvote_power_pct = (
+            max(float(get_dvp()), voting_power_pct) if callable(get_dvp) else voting_power_pct
+        )
 
         # Reference power model (vote_power=100, vote_weight=100) with divisor 50
         power = (100 * 100 / 10000) / 50.0  # = 0.0002

--- a/src/nectar/comment/models.py
+++ b/src/nectar/comment/models.py
@@ -307,8 +307,6 @@ class CommentModelBase(BlockchainObject):
         If the account's current 100% downvote value is insufficient, returns -100.0.
         If the post has no pending payout, returns 0.0.
         """
-        from .account import Account
-
         # Pending payout in HBD
         pending_amt = self.get(
             "pending_payout_value",
@@ -339,7 +337,11 @@ class CommentModelBase(BlockchainObject):
         effective_vests = float(acct.get_effective_vesting_shares())
         final_vests = effective_vests * 1e6
         get_dvp = getattr(acct, "get_downvoting_power", None)
-        downvote_power_pct = float(get_dvp() if callable(get_dvp) else acct.get_voting_power())
+        get_vp = getattr(acct, "get_voting_power", None)
+        voting_power_pct = float(get_vp()) if callable(get_vp) else 0.0
+        downvote_power_pct = (
+            max(float(get_dvp()), voting_power_pct) if callable(get_dvp) else voting_power_pct
+        )
 
         # Reference 100% downvote value using provided sample formula
         power = (100 * 100 / 10000.0) / 50.0  # (vote_power * vote_weight / 10000) / 50
@@ -355,12 +357,13 @@ class CommentModelBase(BlockchainObject):
         ui_pct = -percent_needed_ui * (partial / 100.0)
         # Scale to UI percent
         ui_pct_scaled = ui_pct * 100.0
+        can_zero = ui_pct_scaled >= -100.0
         if ui_pct_scaled < -100.0:
             ui_pct_scaled = -100.0
         if ui_pct_scaled > 0.0:
             ui_pct_scaled = 0.0
 
-        if ui_pct_scaled < 0.0 and not nobroadcast:
+        if can_zero and ui_pct_scaled < 0.0 and not nobroadcast:
             self.downvote(abs(ui_pct_scaled), voter=account)
         return ui_pct_scaled
 
@@ -379,8 +382,6 @@ class CommentModelBase(BlockchainObject):
         - Automatically casts the upvote (use the blockchain instance's ``no_broadcast``
           flag to suppress broadcasting when needed).
         """
-        from .account import Account
-
         # Normalize target HBD
         try:
             target_hbd = float(Amount(hbd, blockchain_instance=self.blockchain))

--- a/src/nectar/version.py
+++ b/src/nectar/version.py
@@ -1,3 +1,3 @@
 """THIS FILE IS GENERATED FROM nectar PYPROJECT.TOML."""
 
-version = "1.0.5"
+version = "1.0.1"

--- a/src/nectarapi/version.py
+++ b/src/nectarapi/version.py
@@ -1,3 +1,3 @@
 """THIS FILE IS GENERATED FROM nectar PYPROJECT.TOML."""
 
-version = "1.0.5"
+version = "1.0.1"

--- a/src/nectarbase/version.py
+++ b/src/nectarbase/version.py
@@ -1,3 +1,3 @@
 """THIS FILE IS GENERATED FROM nectar PYPROJECT.TOML."""
 
-version = "1.0.5"
+version = "1.0.1"

--- a/src/nectargraphenebase/version.py
+++ b/src/nectargraphenebase/version.py
@@ -1,3 +1,3 @@
 """THIS FILE IS GENERATED FROM nectar PYPROJECT.TOML."""
 
-version = "1.0.5"
+version = "1.0.1"

--- a/tests/legacy/legacy_nectar/test_comment.py
+++ b/tests/legacy/legacy_nectar/test_comment.py
@@ -1,17 +1,89 @@
 import unittest
+from unittest import mock
 
 import pytest
 from parameterized import parameterized
 
 from nectar import Hive, exceptions
+from nectar.amount import Amount
 from nectar.comment import AccountPosts, Comment, RankedPosts, RecentByPath, RecentReplies
 from nectar.utils import resolve_authorperm
 from nectar.vote import Vote
 from nectarapi.exceptions import InvalidParameters
+from nectargraphenebase.chains import known_chains
 
 from .nodes import get_hive_nodes
 
 wif = "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"
+
+
+class _FakePrice:
+    def __mul__(self, other):
+        return Amount(1, "HBD", blockchain_instance=other.blockchain)
+
+
+class _FakeBlockchain:
+    backed_token_symbol = "HBD"
+    token_symbol = "HIVE"
+
+    def get_reward_funds(self):
+        return {"recent_claims": "1000000", "reward_balance": "1000.000 HIVE"}
+
+    def get_median_price(self):
+        return _FakePrice()
+
+    def get_network(self):
+        return known_chains["HIVE"]
+
+
+class _FakeAccount:
+    downvoting_power = 100.0
+    voting_power = 100.0
+
+    def __init__(self, account, blockchain_instance=None):
+        self.account = account
+        self.blockchain = blockchain_instance
+
+    def get_effective_vesting_shares(self):
+        return 1_000_000
+
+    def get_downvoting_power(self):
+        return self.downvoting_power
+
+    def get_voting_power(self):
+        return self.voting_power
+
+
+def test_to_zero_does_not_downvote_when_current_power_cannot_zero():
+    _FakeAccount.downvoting_power = 100.0
+    _FakeAccount.voting_power = 100.0
+    comment = Comment.__new__(Comment)
+    dict.__init__(comment)
+    comment["pending_payout_value"] = "1000.000 HBD"
+    comment.blockchain = _FakeBlockchain()
+    comment.downvote = mock.Mock()
+
+    with mock.patch("nectar.comment.models.Account", _FakeAccount):
+        vote_pct = comment.to_zero("alice")
+
+    assert vote_pct == -100.0
+    comment.downvote.assert_not_called()
+
+
+def test_to_zero_uses_regular_voting_power_after_downvote_pool_is_low():
+    _FakeAccount.downvoting_power = 1.0
+    _FakeAccount.voting_power = 50.0
+    comment = Comment.__new__(Comment)
+    dict.__init__(comment)
+    comment["pending_payout_value"] = "1.000 HBD"
+    comment.blockchain = _FakeBlockchain()
+    comment.downvote = mock.Mock()
+
+    with mock.patch("nectar.comment.models.Account", _FakeAccount):
+        vote_pct = comment.to_zero("alice")
+
+    assert vote_pct == -10.0
+    comment.downvote.assert_called_once_with(10.0, voter="alice")
 
 
 class Testcases(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -525,7 +525,7 @@ wheels = [
 
 [[package]]
 name = "hive-nectar"
-version = "1.0.5"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary
- account for regular voting power when downvote mana is lower, matching Hive downvote mana behavior
- avoid auto-broadcasting a full downvote when the helper determines the post cannot be zeroed
- apply the fix to devel's modular comment/vote paths
- set project version metadata to 1.0.1 for this release branch

## Testing
- uv run pytest -q tests/legacy/legacy_nectar/test_comment.py::test_to_zero_does_not_downvote_when_current_power_cannot_zero tests/legacy/legacy_nectar/test_comment.py::test_to_zero_uses_regular_voting_power_after_downvote_pool_is_low
- uv run ruff check src/nectar/comment/models.py src/nectar/blockchain/models/vote.py tests/legacy/legacy_nectar/test_comment.py pyproject.toml
- uv lock --check
- git diff --check