### PR TITLE
Fix stale static default nodes after beacon outages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hive-nectar"
-version = "1.0.3"
+version = "1.0.4"
 description = "Hive Blockchain Python Library"
 readme = "README.md"
 keywords = ["api", "hive", "library", "rpc"]

--- a/src/nectar/wallet/storage.py
+++ b/src/nectar/wallet/storage.py
@@ -52,6 +52,11 @@ def generate_config_store(
         else:
             nodelist = NodeList()
             if blockchain == "hive":
+                # NodeList starts with a non-blocking static fallback, but this
+                # value is persisted as the default configuration. Refresh it
+                # synchronously so a temporary beacon outage does not leave a
+                # permanently stale node list in the user's config.
+                nodelist.update_nodes()
                 nodes = nodelist.get_hive_nodes(testnet=False)
             else:
                 # Hive-only

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,0 +1,26 @@
+import json
+
+from nectar.wallet import storage
+
+
+def test_generate_config_store_refreshes_default_nodes_before_persisting(monkeypatch):
+    refresh_calls = []
+
+    class FakeNodeList:
+        def __init__(self):
+            self.nodes = ["https://static.example"]
+
+        def update_nodes(self):
+            refresh_calls.append(True)
+            self.nodes = ["https://beacon.example"]
+
+        def get_hive_nodes(self, testnet=False):
+            assert testnet is False
+            return self.nodes
+
+    monkeypatch.setattr(storage, "NodeList", FakeNodeList)
+
+    config = storage.generate_config_store({})
+
+    assert json.loads(config["node"]) == ["https://beacon.example"]
+    assert refresh_calls == [True]

--- a/uv.lock
+++ b/uv.lock
@@ -535,7 +535,7 @@ wheels = [
 
 [[package]]
 name = "hive-nectar"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary
- refresh the beacon-backed node list synchronously before persisting default configuration
- prevent a temporary beacon outage from permanently saving the 10-node static fallback
- add a regression test for the persisted default-node selection

Fixes #52.

## Validation
- `uv run pytest tests/unit -q` — 126 passed
- `uv run pytest tests/unit/test_storage.py -q` — 1 passed
- `prek run --all-files` — passed
