### PR TITLE
Fix Hive client resource exhaustion and monitor lifecycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hive-nectar"
-version = "1.0.5"
+version = "1.0.6"
 description = "Hive Blockchain Python Library"
 readme = "README.md"
 keywords = ["api", "hive", "library", "rpc"]

--- a/src/nectar/blockchaininstance/core.py
+++ b/src/nectar/blockchaininstance/core.py
@@ -258,7 +258,9 @@ class BlockChainInstance:
             from nectarapi.pool import NodePoolManager
             from nectarapi.transports import FailoverAsyncTransport, FailoverSyncTransport
 
-            self.pool_manager = NodePoolManager(node_list)
+            self.pool_manager = NodePoolManager(
+                node_list, monitor_interval=kwargs.get("monitor_interval")
+            )
             if self.rpc and hasattr(self.rpc, "nodes"):
                 self.rpc.nodes.pool_manager = self.pool_manager
             self.sync_transport = FailoverSyncTransport(

--- a/src/nectar/blockchaininstance/core.py
+++ b/src/nectar/blockchaininstance/core.py
@@ -151,6 +151,7 @@ class BlockChainInstance:
                 - bundle (bool): If True, enable bundling of operations instead of immediate broadcast.
                 - blocking (str|bool): Wait mode for broadcasts ("head" or "irreversible").
                 - custom_chains (dict): Custom chain definitions.
+                - monitor_interval (float|None): Background node-health monitor interval; use 0 to disable.
                 - use_ledger (bool): If True, enable Ledger Nano signing.
                 - path (str): BIP32 path to derive pubkey from when using Ledger.
                 - config_store: Configuration store object (defaults to the global default).
@@ -254,13 +255,18 @@ class BlockChainInstance:
         if not node_list and self.rpc and hasattr(self.rpc, "nodes"):
             node_list = self.rpc.nodes.get_nodes()
 
+        if self.rpc and hasattr(self.rpc, "nodes"):
+            self.pool_manager = self.rpc.nodes.pool_manager
+
         if len(node_list) > 1:
-            from nectarapi.pool import NodePoolManager
             from nectarapi.transports import FailoverAsyncTransport, FailoverSyncTransport
 
-            self.pool_manager = NodePoolManager(
-                node_list, monitor_interval=kwargs.get("monitor_interval")
-            )
+            if self.pool_manager is None:
+                from nectarapi.pool import NodePoolManager
+
+                self.pool_manager = NodePoolManager(
+                    node_list, monitor_interval=kwargs.get("monitor_interval")
+                )
             if self.rpc and hasattr(self.rpc, "nodes"):
                 self.rpc.nodes.pool_manager = self.pool_manager
             self.sync_transport = FailoverSyncTransport(
@@ -283,6 +289,63 @@ class BlockChainInstance:
         # working node (i.e., self.rpc.url was None), which caused downstream
         # RPC calls to raise RPCConnection("RPC is not connected!").
         return self.rpc is not None and bool(getattr(self.rpc, "url", None))
+
+    def close(self) -> None:
+        """Release all resources owned by this blockchain instance."""
+        rpc = self.rpc
+        self.rpc = None
+        if rpc is not None and hasattr(rpc, "close"):
+            rpc.close()
+
+        client = self.client
+        self.client = None
+        if client is not None:
+            client.close()
+
+        async_client = self.async_client
+        self.async_client = None
+        if async_client is not None:
+            import asyncio
+
+            async def close_async_client() -> None:
+                await async_client.aclose()
+
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                asyncio.run(close_async_client())
+            else:
+                loop.create_task(close_async_client())
+
+        pool_manager = self.pool_manager
+        self.pool_manager = None
+        if pool_manager is not None:
+            pool_manager.close()
+
+    async def aclose(self) -> None:
+        """Asynchronously release all resources owned by this instance."""
+        rpc = self.rpc
+        self.rpc = None
+        if rpc is not None:
+            if hasattr(rpc, "aclose"):
+                await rpc.aclose()
+            elif hasattr(rpc, "close"):
+                rpc.close()
+
+        client = self.client
+        self.client = None
+        if client is not None:
+            client.close()
+
+        async_client = self.async_client
+        self.async_client = None
+        if async_client is not None:
+            await async_client.aclose()
+
+        pool_manager = self.pool_manager
+        self.pool_manager = None
+        if pool_manager is not None:
+            pool_manager.close()
 
     def __repr__(self) -> str:
         if self.offline:

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -165,7 +165,12 @@ class GrapheneRPC:
                 if c not in self.known_chains:
                     self.known_chains[c] = custom_chain[c]
 
-        self.nodes = Nodes(urls, num_retries, num_retries_call)
+        self.nodes = Nodes(
+            urls,
+            num_retries,
+            num_retries_call,
+            monitor_interval=kwargs.get("monitor_interval"),
+        )
         if self.nodes.working_nodes_count == 0:
             log.warning("No working nodes available at initialization")
 
@@ -626,6 +631,17 @@ class GrapheneRPC:
             raise NoApiWithName(error_message)
         raise RPCError(error_message)
 
+    def close(self) -> None:
+        """Close the per-instance failover session, if one was created."""
+        session = self.__dict__.pop("_failover_session", None)
+        if session is not None:
+            session.close()
+        self.session = None
+
+    async def aclose(self) -> None:
+        """Async-compatible cleanup for synchronous RPC clients."""
+        self.close()
+
     # End of Deprecated methods
     ####################################################################
     def __getattr__(self, name):
@@ -823,6 +839,13 @@ class AsyncGrapheneRPC(GrapheneRPC):
         else:
             log.error(f"Unexpected response format: {ret} Node: {self.url}")
             raise RPCError(f"Unexpected response format: {ret}")
+
+    async def aclose(self) -> None:
+        """Close the per-instance asynchronous failover session."""
+        session = self.__dict__.pop("_failover_session", None)
+        if session is not None:
+            await session.aclose()
+        self.session = None
 
     def __getattr__(self, name):
         """Map all methods to RPC calls and pass through the arguments asynchronously."""

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -246,11 +246,18 @@ class GrapheneRPC:
                 # Build the client ONCE per GrapheneRPC instance (stored on self)
                 # to avoid creating a new connection pool on every retry call.
                 if len(self.nodes) > 1:
+                    pool_mgr = getattr(self.nodes, "pool_manager", None)
+                    existing_pool_mgr = self.__dict__.get("_failover_pool_manager")
+                    if (
+                        self.__dict__.get("_failover_session") is not None
+                        and existing_pool_mgr is not pool_mgr
+                    ):
+                        self.__dict__["_failover_session"].close()
+                        self.__dict__.pop("_failover_session", None)
                     if (
                         "_failover_session" not in self.__dict__
                         or self.__dict__["_failover_session"] is None
                     ):
-                        pool_mgr = getattr(self.nodes, "pool_manager", None)
                         if pool_mgr is None:
                             from .pool import NodePoolManager
 
@@ -264,6 +271,7 @@ class GrapheneRPC:
                         self.__dict__["_failover_session"] = httpx2.Client(
                             http2=False, transport=transport
                         )
+                        self.__dict__["_failover_pool_manager"] = pool_mgr
                     self.session = self.__dict__["_failover_session"]
                 else:
                     self.session = shared_httpx_client(self._proxy)
@@ -634,6 +642,7 @@ class GrapheneRPC:
     def close(self) -> None:
         """Close the per-instance failover session, if one was created."""
         session = self.__dict__.pop("_failover_session", None)
+        self.__dict__.pop("_failover_pool_manager", None)
         if session is not None:
             session.close()
         self.session = None
@@ -708,11 +717,26 @@ class AsyncGrapheneRPC(GrapheneRPC):
                 if self.use_tor:
                     self._proxy = "socks5h://localhost:9050"
                 if len(self.nodes) > 1:
+                    pool_mgr = getattr(self.nodes, "pool_manager", None)
+                    existing_pool_mgr = self.__dict__.get("_failover_pool_manager")
+                    if (
+                        self.__dict__.get("_failover_session") is not None
+                        and existing_pool_mgr is not pool_mgr
+                    ):
+                        import asyncio
+
+                        close_result = self.__dict__["_failover_session"].aclose()
+                        try:
+                            loop = asyncio.get_running_loop()
+                        except RuntimeError:
+                            asyncio.run(close_result)
+                        else:
+                            loop.create_task(close_result)
+                        self.__dict__.pop("_failover_session", None)
                     if (
                         "_failover_session" not in self.__dict__
                         or self.__dict__["_failover_session"] is None
                     ):
-                        pool_mgr = getattr(self.nodes, "pool_manager", None)
                         if pool_mgr is None:
                             from .pool import NodePoolManager
 
@@ -726,6 +750,7 @@ class AsyncGrapheneRPC(GrapheneRPC):
                         self.__dict__["_failover_session"] = httpx2.AsyncClient(
                             http2=False, transport=transport
                         )
+                        self.__dict__["_failover_pool_manager"] = pool_mgr
                     self.session = self.__dict__["_failover_session"]
                 else:
                     self.session = shared_async_httpx_client(self._proxy)
@@ -843,6 +868,7 @@ class AsyncGrapheneRPC(GrapheneRPC):
     async def aclose(self) -> None:
         """Close the per-instance asynchronous failover session."""
         session = self.__dict__.pop("_failover_session", None)
+        self.__dict__.pop("_failover_pool_manager", None)
         if session is not None:
             await session.aclose()
         self.session = None

--- a/src/nectarapi/node.py
+++ b/src/nectarapi/node.py
@@ -26,12 +26,14 @@ class Nodes(list):
         urls: Union[str, "Nodes", list[Any], tuple, set, None],
         num_retries: int,
         num_retries_call: int,
+        monitor_interval: float | None = None,
     ) -> None:
         super().__init__()
         self.num_retries = num_retries
         self.num_retries_call = num_retries_call
         self.current_node_index = -1
         self.freeze_current_node = False
+        self.monitor_interval = monitor_interval
         self.pool_manager = None  # Set before __next__ is ever called
         self.set_node_urls(urls)
 
@@ -59,7 +61,7 @@ class Nodes(list):
 
         # Build url list directly from the list elements without using our custom iterator
         raw_urls = [self[i].url for i in range(len(self))]
-        self.pool_manager = NodePoolManager(raw_urls)
+        self.pool_manager = NodePoolManager(raw_urls, monitor_interval=self.monitor_interval)
 
     def __iter__(self) -> "Nodes":  # type: ignore[override]
         return self

--- a/src/nectarapi/node.py
+++ b/src/nectarapi/node.py
@@ -59,6 +59,9 @@ class Nodes(list):
 
         from .pool import NodePoolManager
 
+        if self.pool_manager is not None:
+            self.pool_manager.close()
+
         # Build url list directly from the list elements without using our custom iterator
         raw_urls = [self[i].url for i in range(len(self))]
         self.pool_manager = NodePoolManager(raw_urls, monitor_interval=self.monitor_interval)

--- a/src/nectarapi/pool.py
+++ b/src/nectarapi/pool.py
@@ -68,7 +68,12 @@ class NodePoolManager:
     def stop_monitoring(self) -> None:
         with self.lock:
             self._stop_event.set()
-            self._monitor_thread = None
+            monitor_thread = self._monitor_thread
+        if monitor_thread is not None and monitor_thread is not threading.current_thread():
+            monitor_thread.join()
+        with self.lock:
+            if self._monitor_thread is monitor_thread:
+                self._monitor_thread = None
 
     def close(self) -> None:
         self.stop_monitoring()

--- a/tests/unit/test_failover.py
+++ b/tests/unit/test_failover.py
@@ -50,6 +50,17 @@ class TestRPCNode:
 
 
 class TestNodePoolManager:
+    def test_nodes_forwards_monitor_interval_to_pool(self):
+        nodes = Nodes(
+            ["https://api.hive.blog", "https://api.openhive.network"],
+            num_retries=3,
+            num_retries_call=2,
+            monitor_interval=0.0,
+        )
+
+        assert nodes.pool_manager.monitor_interval == 0.0
+        assert nodes.pool_manager._monitor_thread is None
+
     def test_init_with_nodes(self):
         pm = NodePoolManager(["https://api.hive.blog", "https://api.openhive.network"])
         assert len(pm.nodes) == 2

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -1,0 +1,60 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from nectar.blockchaininstance.core import BlockChainInstance
+from nectarapi.graphenerpc import GrapheneRPC
+
+
+def test_graphene_rpc_close_releases_only_per_instance_session():
+    rpc = GrapheneRPC.__new__(GrapheneRPC)
+    rpc.session = session = MagicMock()
+    rpc._failover_session = session
+
+    rpc.close()
+
+    session.close.assert_called_once_with()
+    assert rpc.session is None
+    assert "_failover_session" not in rpc.__dict__
+
+
+def test_blockchain_instance_close_releases_sync_and_async_resources():
+    instance = BlockChainInstance.__new__(BlockChainInstance)
+    rpc = MagicMock()
+    client = MagicMock()
+    instance.rpc = rpc
+    instance.client = client
+    async_client = AsyncMock()
+    instance.async_client = async_client
+    pool_manager = MagicMock()
+    instance.pool_manager = pool_manager
+
+    instance.close()
+
+    rpc.close.assert_called_once_with()
+    client.close.assert_called_once_with()
+    asyncio.run(async_client.aclose())
+    pool_manager.close.assert_called_once_with()
+    assert instance.rpc is None
+    assert instance.client is None
+    assert instance.async_client is None
+    assert instance.pool_manager is None
+
+
+def test_blockchain_instance_aclose_releases_async_rpc_resources():
+    instance = BlockChainInstance.__new__(BlockChainInstance)
+    rpc = MagicMock()
+    rpc.aclose = AsyncMock()
+    client = MagicMock()
+    async_client = AsyncMock()
+    pool_manager = MagicMock()
+    instance.rpc = rpc
+    instance.client = client
+    instance.async_client = async_client
+    instance.pool_manager = pool_manager
+
+    asyncio.run(instance.aclose())
+
+    rpc.aclose.assert_awaited_once_with()
+    client.close.assert_called_once_with()
+    async_client.aclose.assert_awaited_once_with()
+    pool_manager.close.assert_called_once_with()

--- a/uv.lock
+++ b/uv.lock
@@ -535,7 +535,7 @@ wheels = [
 
 [[package]]
 name = "hive-nectar"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary

Addresses the production resource-exhaustion concerns raised in #54, including `EMFILE` failures and zombie Nectar stream/client recovery.

## What changed

- Forward `monitor_interval` through `Hive`/`BlockChainInstance` into the actual `NodePoolManager`, so `monitor_interval=0` really disables background probes.
- Reuse the pool created by `Nodes` instead of replacing it during connection setup.
- Join monitor threads during shutdown, and retire old pools when node URLs change.
- Rebuild stale per-instance failover sessions when their pool changes.
- Add synchronous and asynchronous client lifecycle methods: `close()` and `aclose()`.
- Keep process-wide shared HTTP clients untouched.
- Add regression coverage for monitor configuration and resource cleanup.
- Bump the patch release with `uv version --bump patch` in a separate final commit: `1.0.5` -> `1.0.6`.

## Validation

- `uv run --locked pytest` — 133 passed, 2 existing deprecation warnings
- `uv run --locked prek run --all-files` — passed

Fixes #54
