### PR TITLE
fix(lifecycle): hard-close RPC clients and default monitor off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes (long-running client lifecycle)
 
-- **Hard close**: `GrapheneRPC.close()` / `aclose()` now mark the client closed. Subsequent `rpcconnect()`, `next()`, and request sends raise `RPCClosed` instead of silently recreating sessions (which leaked FDs under rebuild loops).
+- **Hard close**: `GrapheneRPC.close()` / `aclose()` now mark the client closed. Subsequent `rpcconnect()`, `next()`, `rpcexec()`, and request sends raise `RPCClosed` instead of silently recreating sessions (which leaked FDs under rebuild loops).
+- **Async hard close**: `AsyncGrapheneRPC.aclose()` matches sync semantics (sets `_closed`, stops `NodePoolManager`, acloses the failover session) instead of only dropping the httpx client.
 - **Monitor teardown on RPC close**: `GrapheneRPC.close()` stops the associated `NodePoolManager` / `NodePoolMonitor` thread. Previously only `BlockChainInstance.close()` stopped monitors, so apps that closed `rpc` alone left background probe threads running.
 - **Safe node iteration after teardown**: `Nodes.__next__` raises `WorkingNodeMissing` when `pool_manager` is `None` instead of `AttributeError`.
 - **Monitor default off**: `NodePoolManager` default `monitor_interval` is `0` (disabled). Background monitoring is opt-in via `Hive(..., monitor_interval=30)` (or equivalent). The previous production default of 30s caused thread/FD growth when many short-lived multi-node clients were created; the pytest-only auto-disable was removed in favor of a single explicit default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixes (long-running client lifecycle)
+
+- **Hard close**: `GrapheneRPC.close()` / `aclose()` now mark the client closed. Subsequent `rpcconnect()`, `next()`, and request sends raise `RPCClosed` instead of silently recreating sessions (which leaked FDs under rebuild loops).
+- **Monitor teardown on RPC close**: `GrapheneRPC.close()` stops the associated `NodePoolManager` / `NodePoolMonitor` thread. Previously only `BlockChainInstance.close()` stopped monitors, so apps that closed `rpc` alone left background probe threads running.
+- **Safe node iteration after teardown**: `Nodes.__next__` raises `WorkingNodeMissing` when `pool_manager` is `None` instead of `AttributeError`.
+- **Monitor default off**: `NodePoolManager` default `monitor_interval` is `0` (disabled). Background monitoring is opt-in via `Hive(..., monitor_interval=30)` (or equivalent). The previous production default of 30s caused thread/FD growth when many short-lived multi-node clients were created; the pytest-only auto-disable was removed in favor of a single explicit default.
+
 ## 1.0.6 - 2026-06-20
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "hive-nectar"
-version = "1.0.6"
+version = "1.0.7"
 description = "Hive Blockchain Python Library"
 readme = "README.md"
 keywords = ["api", "hive", "library", "rpc"]

--- a/src/nectar/blockchaininstance/core.py
+++ b/src/nectar/blockchaininstance/core.py
@@ -151,7 +151,8 @@ class BlockChainInstance:
                 - bundle (bool): If True, enable bundling of operations instead of immediate broadcast.
                 - blocking (str|bool): Wait mode for broadcasts ("head" or "irreversible").
                 - custom_chains (dict): Custom chain definitions.
-                - monitor_interval (float|None): Background node-health monitor interval; use 0 to disable.
+                - monitor_interval (float|None): Background node-health monitor interval in seconds.
+                  Default is disabled (0). Pass a positive value (e.g. 30) to opt in.
                 - use_ledger (bool): If True, enable Ledger Nano signing.
                 - path (str): BIP32 path to derive pubkey from when using Ledger.
                 - config_store: Configuration store object (defaults to the global default).

--- a/src/nectarapi/exceptions.py
+++ b/src/nectarapi/exceptions.py
@@ -34,6 +34,17 @@ class RPCConnection(NectarApiException):
     pass
 
 
+class RPCClosed(RPCConnection):
+    """Raised when an RPC client is used after ``close()`` / ``aclose()``.
+
+    Long-running apps intentionally close clients on rebuild/rotate. A soft
+    reconnect after close recreates sessions and can leak FDs/threads; callers
+    should construct a new client instead of reusing a closed one.
+    """
+
+    pass
+
+
 class RPCError(NectarApiException):
     """RPCError Exception."""
 

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -567,11 +567,13 @@ class GrapheneRPC:
             The RPC `result` (any) for a single request, or a list of results for a batch response.
 
         Raises:
+            RPCClosed: if the client was intentionally closed.
             WorkingNodeMissing: if no working nodes are available.
             RPCConnection: if the client is not connected to any node.
             RPCError: for server-reported errors or unexpected / non-JSON responses that indicate an RPC failure.
             KeyboardInterrupt: if execution is interrupted by the user.
         """
+        self._ensure_open()
         log.debug(f"Payload: {json.dumps(payload)}")
         if self.nodes.working_nodes_count == 0:
             raise WorkingNodeMissing("No working nodes available.")
@@ -841,6 +843,7 @@ class AsyncGrapheneRPC(GrapheneRPC):
         """
         Execute the given JSON-RPC payload asynchronously.
         """
+        self._ensure_open()
         log.debug(f"Payload: {json.dumps(payload)}")
         if self.nodes.working_nodes_count == 0:
             raise WorkingNodeMissing("No working nodes available.")
@@ -918,12 +921,37 @@ class AsyncGrapheneRPC(GrapheneRPC):
             raise RPCError(f"Unexpected response format: {ret}")
 
     async def aclose(self) -> None:
-        """Close the per-instance asynchronous failover session."""
+        """
+        Fully tear down this async RPC client (hard-close).
+
+        Mirrors :meth:`GrapheneRPC.close`: marks closed, stops NodePoolManager
+        monitors, and acloses the per-instance async failover session. Safe to
+        call more than once.
+        """
+        self._closed = True
+
+        try:
+            nodes = getattr(self, "nodes", None)
+            pool_mgr = getattr(nodes, "pool_manager", None) if nodes is not None else None
+            if pool_mgr is None:
+                pool_mgr = self.__dict__.get("_failover_pool_manager")
+            if pool_mgr is not None:
+                try:
+                    pool_mgr.close()
+                except Exception:
+                    log.debug("Error stopping NodePoolManager during aclose", exc_info=True)
+        except Exception:
+            log.debug("Error resolving pool manager during aclose", exc_info=True)
+
         session = self.__dict__.pop("_failover_session", None)
         self.__dict__.pop("_failover_pool_manager", None)
         if session is not None:
-            await session.aclose()
+            try:
+                await session.aclose()
+            except Exception:
+                log.debug("Error aclosing failover session", exc_info=True)
         self.session = None
+        self.url = None
 
     def __getattr__(self, name):
         """Map all methods to RPC calls and pass through the arguments asynchronously."""

--- a/src/nectarapi/graphenerpc.py
+++ b/src/nectarapi/graphenerpc.py
@@ -18,6 +18,7 @@ from .exceptions import (
     InvalidParameters,
     NoApiWithName,
     NoMethodWithName,
+    RPCClosed,
     RPCConnection,
     RPCError,
     RPCErrorDoRetry,
@@ -179,14 +180,22 @@ class GrapheneRPC:
         self.url = None
         self.session: httpx2.Client | None = None
         self.rpc_queue = []
+        # Hard-closed after close()/aclose(); refuse reconnect (see RPCClosed).
+        self._closed = False
         if kwargs.get("autoconnect", True):
             self.rpcconnect()
+
+    def _ensure_open(self) -> None:
+        """Raise if this client was intentionally closed."""
+        if getattr(self, "_closed", False):
+            raise RPCClosed("RPC client is closed; create a new client instead of reconnecting")
 
     def _handle_transport_error(self, exc: Exception, *, call_retry: bool = False) -> None:
         """
         Centralized transport error handling: increment counters, defer to node retry policy,
         and reconnect to the next node.
         """
+        self._ensure_open()
         self.nodes.increase_error_cnt()
         self.nodes.sleep_and_check_retries(str(exc), sleep=False, call_retry=call_retry)
         self.rpcconnect()
@@ -207,6 +216,11 @@ class GrapheneRPC:
     def error_cnt(self) -> int:
         return self.nodes.error_cnt
 
+    @property
+    def closed(self) -> bool:
+        """True after :meth:`close` / :meth:`aclose` has been called."""
+        return bool(getattr(self, "_closed", False))
+
     def get_request_id(self) -> int:
         """Get request id."""
         self._request_id += 1
@@ -216,6 +230,7 @@ class GrapheneRPC:
         """
         Advance to the next available RPC node and attempt to (re)connect.
         """
+        self._ensure_open()
         self.rpcconnect()
 
     def rpcconnect(self, next_url: bool = True) -> None:
@@ -228,9 +243,11 @@ class GrapheneRPC:
             next_url (bool): If True, advance to the next node before attempting connection; if False, retry the current node.
 
         Raises:
+            RPCClosed: If :meth:`close` was already called on this client.
             RPCError: When a get_config probe returns no properties (connection reached but no config received).
             KeyboardInterrupt: Propagated if the operation is interrupted by the user.
         """
+        self._ensure_open()
         if self.nodes.working_nodes_count == 0:
             return
         while True:
@@ -297,6 +314,7 @@ class GrapheneRPC:
         Raises:
             UnauthorizedError: If the HTTP response status code is 401 (Unauthorized).
         """
+        self._ensure_open()
         if self.session is None:
             raise RPCConnection("Session must be initialized")
         if self.url is None:
@@ -640,12 +658,44 @@ class GrapheneRPC:
         raise RPCError(error_message)
 
     def close(self) -> None:
-        """Close the per-instance failover session, if one was created."""
+        """
+        Fully tear down this RPC client for long-running process safety.
+
+        - Marks the client hard-closed (subsequent ``rpcconnect`` / RPC raises
+          :class:`RPCClosed` instead of silently recreating a session).
+        - Stops ``NodePoolManager`` background monitors (``GrapheneRPC.close``
+          previously left ``NodePoolMonitor`` threads running).
+        - Closes the per-instance failover httpx session when present.
+
+        Does not close the process-wide shared httpx client used for single-node
+        setups. Safe to call more than once.
+        """
+        self._closed = True
+
+        # Stop background health monitors before dropping the session so probe
+        # threads do not keep sockets open against a half-closed client.
+        try:
+            nodes = getattr(self, "nodes", None)
+            pool_mgr = getattr(nodes, "pool_manager", None) if nodes is not None else None
+            if pool_mgr is None:
+                pool_mgr = self.__dict__.get("_failover_pool_manager")
+            if pool_mgr is not None:
+                try:
+                    pool_mgr.close()
+                except Exception:
+                    log.debug("Error stopping NodePoolManager during close", exc_info=True)
+        except Exception:
+            log.debug("Error resolving pool manager during close", exc_info=True)
+
         session = self.__dict__.pop("_failover_session", None)
         self.__dict__.pop("_failover_pool_manager", None)
         if session is not None:
-            session.close()
+            try:
+                session.close()
+            except Exception:
+                log.debug("Error closing failover session", exc_info=True)
         self.session = None
+        self.url = None
 
     async def aclose(self) -> None:
         """Async-compatible cleanup for synchronous RPC clients."""
@@ -705,6 +755,7 @@ class AsyncGrapheneRPC(GrapheneRPC):
         """
         Selects and establishes connection to an available RPC node asynchronously.
         """
+        self._ensure_open()
         if self.nodes.working_nodes_count == 0:
             return
         while True:
@@ -765,6 +816,7 @@ class AsyncGrapheneRPC(GrapheneRPC):
         """
         Send the prepared RPC payload to the currently connected node via HTTP POST asynchronously.
         """
+        self._ensure_open()
         if self.session is None:
             raise RPCConnection("Session must be initialized")
         if self.url is None:

--- a/src/nectarapi/node.py
+++ b/src/nectarapi/node.py
@@ -3,7 +3,7 @@ import re
 import time
 from typing import Any, Union
 
-from .exceptions import CallRetriesReached, NumRetriesReached
+from .exceptions import CallRetriesReached, NumRetriesReached, WorkingNodeMissing
 
 log = logging.getLogger(__name__)
 
@@ -74,6 +74,11 @@ class Nodes(list):
             return self.url
         if len(self) == 0:
             raise StopIteration
+        if self.pool_manager is None:
+            # After close / partial teardown, never AttributeError on None.
+            raise WorkingNodeMissing(
+                "Node pool manager is not available (client closed or not initialized)"
+            )
 
         best_node = self.pool_manager.get_active_node()
         # Update current_node_index for compatibility

--- a/src/nectarapi/noderpc.py
+++ b/src/nectarapi/noderpc.py
@@ -50,11 +50,13 @@ class NodeRPC(GrapheneRPC):
             payload (dict or list): JSON-RPC payload to send (method, params, id, etc.).
 
         Raises:
+            RPCClosed: if the client was intentionally closed.
             RPCConnection: if no RPC URL is configured (connection not established).
             CallRetriesReached: when the node-manager's retry budget is exhausted and no alternative node can be used.
             RPCError: when the remote node returns an RPC error that is not recoverable by retries/switching.
             Exception: any other unexpected exception raised by the underlying RPC call is propagated.
         """
+        self._ensure_open()
         if self.url is None:
             raise exceptions.RPCConnection("RPC is not connected!")
         reply = super().rpcexec(payload)
@@ -96,6 +98,7 @@ class AsyncNodeRPC(AsyncGrapheneRPC):
         """
         Execute an RPC call with node-aware retry and Hive-specific error handling asynchronously.
         """
+        self._ensure_open()
         if self.url is None:
             raise exceptions.RPCConnection("RPC is not connected!")
         reply = await super().rpcexec_async(payload)

--- a/src/nectarapi/pool.py
+++ b/src/nectarapi/pool.py
@@ -40,15 +40,14 @@ class NodePoolManager:
         self._active_node = self.nodes[0]
         self._recalculate_best_node()
 
-        import sys
-
+        # Default off: background NodePoolMonitor probes open sockets and keep
+        # threads alive for the life of each multi-node client. Long-running
+        # apps that construct many short-lived Hive/RPC instances leak FDs when
+        # the default was 30s. Opt in with monitor_interval>0 (e.g. 30).
         if monitor_interval is None:
-            if "pytest" in sys.modules or "unittest" in sys.modules:
-                self.monitor_interval = 0.0
-            else:
-                self.monitor_interval = 30.0
+            self.monitor_interval = 0.0
         else:
-            self.monitor_interval = monitor_interval
+            self.monitor_interval = float(monitor_interval)
 
         self._stop_event = threading.Event()
         self._monitor_thread = None

--- a/src/nectarapi/pool.py
+++ b/src/nectarapi/pool.py
@@ -40,7 +40,7 @@ class NodePoolManager:
         self._active_node = self.nodes[0]
         self._recalculate_best_node()
 
-        # Default off: background NodePoolMonitor probes open sockets and keep
+        # Default off: background NodePoolMonitor probes open sockets and keeps
         # threads alive for the life of each multi-node client. Long-running
         # apps that construct many short-lived Hive/RPC instances leak FDs when
         # the default was 30s. Opt in with monitor_interval>0 (e.g. 30).

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -1,20 +1,65 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from nectar.blockchaininstance.core import BlockChainInstance
+from nectarapi.exceptions import RPCClosed, WorkingNodeMissing
 from nectarapi.graphenerpc import GrapheneRPC
+from nectarapi.node import Nodes
+from nectarapi.pool import NodePoolManager
 
 
-def test_graphene_rpc_close_releases_only_per_instance_session():
+def test_graphene_rpc_close_releases_session_and_stops_pool_monitor():
     rpc = GrapheneRPC.__new__(GrapheneRPC)
+    rpc._closed = False
     rpc.session = session = MagicMock()
     rpc._failover_session = session
+    rpc.url = "https://api.hive.blog"
+    pool_mgr = MagicMock()
+    nodes = MagicMock()
+    nodes.pool_manager = pool_mgr
+    rpc.nodes = nodes
 
     rpc.close()
 
     session.close.assert_called_once_with()
+    pool_mgr.close.assert_called_once_with()
     assert rpc.session is None
+    assert rpc.url is None
+    assert rpc.closed is True
     assert "_failover_session" not in rpc.__dict__
+
+
+def test_graphene_rpc_close_is_hard_no_reconnect():
+    rpc = GrapheneRPC.__new__(GrapheneRPC)
+    rpc._closed = False
+    rpc.session = MagicMock()
+    rpc.nodes = MagicMock()
+    rpc.nodes.pool_manager = MagicMock()
+    rpc.nodes.working_nodes_count = 2
+    rpc.url = "https://api.hive.blog"
+
+    rpc.close()
+
+    with pytest.raises(RPCClosed):
+        rpc.rpcconnect()
+    with pytest.raises(RPCClosed):
+        rpc.next()
+    with pytest.raises(RPCClosed):
+        rpc.request_send(b"{}")
+
+
+def test_graphene_rpc_close_is_idempotent():
+    rpc = GrapheneRPC.__new__(GrapheneRPC)
+    rpc._closed = False
+    rpc.session = None
+    rpc.nodes = MagicMock()
+    rpc.nodes.pool_manager = MagicMock()
+
+    rpc.close()
+    rpc.close()
+    assert rpc.closed is True
 
 
 def test_blockchain_instance_close_releases_sync_and_async_resources():
@@ -58,3 +103,29 @@ def test_blockchain_instance_aclose_releases_async_rpc_resources():
     client.close.assert_called_once_with()
     async_client.aclose.assert_awaited_once_with()
     pool_manager.close.assert_called_once_with()
+
+
+def test_nodes_next_without_pool_manager_raises_clear_error():
+    nodes = Nodes(["https://a.example", "https://b.example"], num_retries=1, num_retries_call=1)
+    nodes.pool_manager = None
+    with pytest.raises(WorkingNodeMissing, match="pool manager is not available"):
+        next(nodes)
+
+
+def test_default_monitor_interval_is_disabled():
+    pm = NodePoolManager(["https://api.hive.blog", "https://api2.hive.blog"])
+    assert pm.monitor_interval == 0.0
+    assert pm._monitor_thread is None
+    pm.close()
+
+
+def test_explicit_monitor_interval_starts_thread():
+    pm = NodePoolManager(
+        ["https://api.hive.blog", "https://api2.hive.blog"],
+        monitor_interval=30.0,
+    )
+    assert pm.monitor_interval == 30.0
+    assert pm._monitor_thread is not None
+    assert pm._monitor_thread.is_alive()
+    pm.close()
+    assert pm._monitor_thread is None or not pm._monitor_thread.is_alive()

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -5,7 +5,7 @@ import pytest
 
 from nectar.blockchaininstance.core import BlockChainInstance
 from nectarapi.exceptions import RPCClosed, WorkingNodeMissing
-from nectarapi.graphenerpc import GrapheneRPC
+from nectarapi.graphenerpc import AsyncGrapheneRPC, GrapheneRPC
 from nectarapi.node import Nodes
 from nectarapi.pool import NodePoolManager
 
@@ -48,6 +48,45 @@ def test_graphene_rpc_close_is_hard_no_reconnect():
         rpc.next()
     with pytest.raises(RPCClosed):
         rpc.request_send(b"{}")
+    with pytest.raises(RPCClosed):
+        rpc.rpcexec({"jsonrpc": "2.0", "method": "condenser_api.get_dynamic_global_properties", "params": [], "id": 1})
+
+
+def test_async_graphene_rpc_aclose_is_hard_close():
+    """AsyncGrapheneRPC.aclose must hard-close (not only drop the session)."""
+    rpc = AsyncGrapheneRPC.__new__(AsyncGrapheneRPC)
+    rpc._closed = False
+    rpc.url = "https://api.hive.blog"
+    session = AsyncMock()
+    rpc.session = session
+    rpc._failover_session = session
+    pool_mgr = MagicMock()
+    nodes = MagicMock()
+    nodes.pool_manager = pool_mgr
+    rpc.nodes = nodes
+
+    asyncio.run(rpc.aclose())
+
+    assert rpc.closed is True
+    assert rpc.session is None
+    assert rpc.url is None
+    pool_mgr.close.assert_called_once_with()
+    session.aclose.assert_awaited_once()
+    assert "_failover_session" not in rpc.__dict__
+
+    with pytest.raises(RPCClosed):
+        rpc.rpcconnect()
+    with pytest.raises(RPCClosed):
+        asyncio.run(
+            rpc.rpcexec_async(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "condenser_api.get_dynamic_global_properties",
+                    "params": [],
+                    "id": 1,
+                }
+            )
+        )
 
 
 def test_graphene_rpc_close_is_idempotent():

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -49,7 +49,14 @@ def test_graphene_rpc_close_is_hard_no_reconnect():
     with pytest.raises(RPCClosed):
         rpc.request_send(b"{}")
     with pytest.raises(RPCClosed):
-        rpc.rpcexec({"jsonrpc": "2.0", "method": "condenser_api.get_dynamic_global_properties", "params": [], "id": 1})
+        rpc.rpcexec(
+            {
+                "jsonrpc": "2.0",
+                "method": "condenser_api.get_dynamic_global_properties",
+                "params": [],
+                "id": 1,
+            }
+        )
 
 
 def test_async_graphene_rpc_aclose_is_hard_close():

--- a/uv.lock
+++ b/uv.lock
@@ -7,21 +7,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P3D"
-
-[options.exclude-newer-package]
-semble = false
-qtile = false
-ty = false
-nectarengine = false
-yt-dlp = false
-ruff = false
-prek = false
-strip-tags = false
-hive-nectar = false
-
 [[package]]
 name = "alabaster"
 version = "1.0.0"
@@ -517,7 +502,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -535,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "hive-nectar"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },
@@ -646,7 +631,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1016,23 +1001,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -1047,23 +1032,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
+    { name = "babel", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
+    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
+    { name = "packaging", marker = "python_full_version == '3.11.*'" },
+    { name = "pygments", marker = "python_full_version == '3.11.*'" },
+    { name = "requests", marker = "python_full_version == '3.11.*'" },
+    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -1078,23 +1063,23 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [


### PR DESCRIPTION
Long-running Hive monitors (e.g. hive_monitor rebuild loops) hit EMFILE and zombie next() stalls when multi-node clients left NodePoolMonitor threads alive after GrapheneRPC.close(), soft-reconnected after intentional close, and defaulted to a 30s background probe interval.

- GrapheneRPC.close() stops NodePoolManager and sets a hard-closed flag
- Subsequent rpcconnect/next/request raise RPCClosed (no silent reconnect)
- Nodes.__next__ guards pool_manager is None with WorkingNodeMissing
- Default monitor_interval is 0; opt in with monitor_interval>0
- Bump version to 1.0.7; unit tests for close and monitor defaults